### PR TITLE
feat: should retain "unread" status when the browser tab is not active or when the browser window is not focused.

### DIFF
--- a/src/component/chat/transcript/TranscriptView.tsx
+++ b/src/component/chat/transcript/TranscriptView.tsx
@@ -1,3 +1,4 @@
+import useWindowFocus from "hook/useWindowFocus";
 import { useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 
@@ -34,12 +35,13 @@ type ScrollEvent = React.UIEvent<HTMLDivElement, UIEvent> & {
 const TranscriptView = ({ transcript, markAsRead }: TranscriptViewProps) => {
     const [isAtBottom, setAtBottom] = useState(true);
     const scrollTargetRef = useRef(null);
+    const isPageVisible = useWindowFocus();
 
     useEffect(() => {
-        if (isAtBottom && transcript.unreadMessageCount) {
+        if (isPageVisible && isAtBottom && transcript.unreadMessageCount) {
             markAsRead();
         }
-    }, [isAtBottom, markAsRead, transcript.unreadMessageCount]);
+    }, [isPageVisible, isAtBottom, markAsRead, transcript.unreadMessageCount]);
 
     useEffect(() => {
         // Automatically scroll to the bottom when a new message arrives.
@@ -69,7 +71,7 @@ const TranscriptView = ({ transcript, markAsRead }: TranscriptViewProps) => {
             <QuickscrollButton
                 scroll={scrollToBottom}
                 hasUnreadMessages={transcript.unreadMessageCount > 0}
-                isAtBottom
+                isAtBottom={isAtBottom}
             />
         </StyledTranscriptView>
     );

--- a/src/hook/useWindowFocus.ts
+++ b/src/hook/useWindowFocus.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from "react";
+
+const useWindowFocus = () => {
+    const [isFocused, setFocused] = useState(false);
+
+    useEffect(() => {
+        const onFocus = () => setFocused(true);
+        const onBlur = () => setFocused(false);
+
+        window.addEventListener("focus", onFocus);
+        window.addEventListener("blur", onBlur);
+        return () => {
+            window.removeEventListener("focus", onFocus);
+            window.removeEventListener("blur", onBlur);
+        };
+    }, []);
+
+    return isFocused;
+};
+
+export default useWindowFocus;


### PR DESCRIPTION
feat: should retain "unread" status when the browser tab is not active or when the browser window is not focused.